### PR TITLE
chore: bump vendored CLI to 0.9.13 (codex sub-agent double-count fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4594,7 +4594,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibe-core"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "dirs 5.0.1",
  "serde",
@@ -4604,7 +4604,7 @@ dependencies = [
 
 [[package]]
 name = "vibe-usage-app"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "auto-launch",
  "dirs 5.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/core", "src-tauri"]
 
 [workspace.package]
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 rust-version = "1.88"
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibe-usage-app-windows",
   "private": true,
-  "version": "0.5.8",
+  "version": "0.5.9",
   "type": "module",
   "description": "Vibe Usage for Windows — AI coding tool token usage tracker (Windows port of the macOS Vibe Usage app)",
   "scripts": {

--- a/scripts/vendor-cli.mjs
+++ b/scripts/vendor-cli.mjs
@@ -16,7 +16,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-const CLI_VERSION = "0.9.8"; // bump deliberately; releases go through regression tests
+const CLI_VERSION = "0.9.13"; // bump deliberately; releases go through regression tests
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const destDir = path.join(root, "src-tauri", "resources", "cli");

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Vibe Usage",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "identifier": "ai.vibecafe.vibe-usage.windows",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## 背景

vibe-usage 0.9.12/0.9.13 修复了 codex 解析器把 sub-agent 继承的父会话累计 token 记成单个巨型 bucket 的 bug。Windows 应用 vendor 的还是受影响的 0.9.8。

vibecafe.ai 服务端已上线合理性护栏(单 bucket output+reasoning >5M / input >500M / cache >2B 直接丢弃),所以在这版发布之前,Windows 用户的巨型 artifact 行会被静默丢弃——升级后解析即正确。

## 变更

- `scripts/vendor-cli.mjs`: `CLI_VERSION` 0.9.8 → 0.9.13

发布前请按常规跑回归测试(`node scripts/vendor-cli.mjs` 重新 vendor 后构建)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)