### PR TITLE
Fix daily trend timezone grouping

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -22,9 +22,18 @@ export function computedTotal(b: UsageBucket): number {
   return b.inputTokens + b.outputTokens + b.reasoningOutputTokens + b.cachedInputTokens;
 }
 
-/** Day string (yyyy-MM-dd) for grouping — UTC prefix, same as Swift `bucketStart.prefix(10)` */
+function localDateKey(value: string): string {
+  const date = new Date(value);
+  if (isNaN(date.getTime())) return value.slice(0, 10);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+/** Local calendar day for grouping, matching the web dashboard's timezone semantics. */
 export function bucketDayKey(b: UsageBucket): string {
-  return b.bucketStart.slice(0, 10);
+  return localDateKey(b.bucketStart);
 }
 
 /** Hour string (yyyy-MM-ddTHH) for hourly grouping — UTC prefix(13) */
@@ -51,7 +60,7 @@ export interface UsageSession {
 }
 
 export function sessionDayKey(s: UsageSession): string {
-  return s.firstMessageAt.slice(0, 10);
+  return localDateKey(s.firstMessageAt);
 }
 
 export function sessionHourKey(s: UsageSession): string {

--- a/tests/aggregate.test.ts
+++ b/tests/aggregate.test.ts
@@ -96,25 +96,34 @@ describe("summarize", () => {
 });
 
 describe("buildChartData", () => {
-  it("daily mode fills every slot and aggregates by UTC dayKey", () => {
-    const now = new Date("2026-07-03T12:00:00");
-    const data = buildChartData(
-      [bucket({ bucketStart: "2026-07-01T04:00:00.000Z", inputTokens: 7 })],
-      [session({ firstMessageAt: "2026-07-01T04:00:00.000Z", activeSeconds: 600 })],
-      "7D",
-      7,
-      null,
-      now,
-    );
-    expect(data).toHaveLength(7);
-    const day = data.find((d) => d.id === "2026-07-01")!;
-    expect(day.input).toBe(7);
-    expect(day.activeMinutes).toBe(10);
-    // reasoning folded into output
-    expect(day.output).toBe(50 + 10);
-    expect(barTotal(day)).toBe(7 + 60 + 200);
-    // empty slots exist with zeros
-    expect(data.filter((d) => barTotal(d) === 0).length).toBe(6);
+  it("daily mode fills every slot and aggregates by local calendar day", () => {
+    const originalTz = process.env.TZ;
+    try {
+      process.env.TZ = "Asia/Shanghai";
+      const now = new Date("2026-07-03T12:00:00");
+      const data = buildChartData(
+        // The API represents Asia/Shanghai local midnight as the previous UTC
+        // date. Grouping by the raw ISO prefix would put this data on July 1.
+        [bucket({ bucketStart: "2026-07-01T16:00:00.000Z", inputTokens: 7 })],
+        [session({ firstMessageAt: "2026-07-01T16:00:00.000Z", activeSeconds: 600 })],
+        "7D",
+        7,
+        null,
+        now,
+      );
+      expect(data).toHaveLength(7);
+      const day = data.find((d) => d.id === "2026-07-02")!;
+      expect(day.input).toBe(7);
+      expect(day.activeMinutes).toBe(10);
+      // reasoning folded into output
+      expect(day.output).toBe(50 + 10);
+      expect(barTotal(day)).toBe(7 + 60 + 200);
+      // empty slots exist with zeros
+      expect(data.filter((d) => barTotal(d) === 0).length).toBe(6);
+    } finally {
+      if (originalTz === undefined) delete process.env.TZ;
+      else process.env.TZ = originalTz;
+    }
   });
 
   it("24H mode produces a 24-slot rolling window; today grows from midnight", () => {


### PR DESCRIPTION
## What changed

- Group daily usage buckets and sessions by the user's local calendar date.
- Keep hourly ranges on their existing UTC hour keys.
- Add an Asia/Shanghai regression case covering local midnight encoded as the previous UTC date.

## Root cause

The API already aggregates multi-day data in the user's timezone and returns each local midnight as its UTC instant. The Windows client grouped those values with `timestamp.slice(0, 10)`, so Asia/Shanghai midnight (for example, July 2 00:00) was displayed under July 1. The web dashboard converts the same instant back to the local date.

## Validation

- `pnpm test -- tests/aggregate.test.ts` — 12 tests passed
- `pnpm build`
- `git diff --check`

Fixes #5